### PR TITLE
Bump dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.1
+    gravitee: gravitee-io/gravitee@4.12.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,4 @@
 {
-    "extends": ["config:base", ":label(dependencies)"],
-    "rebaseWhen": "conflicted",
-    "packageRules": [
-        {
-            "matchDatasources": ["orb"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "ci"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "chore"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["major"],
-            "semanticCommitType": "chore"
-        }
-    ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["local>gravitee-io/renovate-config:plugin"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,11 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>6.0.3</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-apim.version>4.0.0-SNAPSHOT</gravitee-apim.version>
-        <gravitee-sse.version>4.0.0</gravitee-sse.version>
-        <gravitee-http-post.version>1.0.0</gravitee-http-post.version>
-        <gravitee-reactor-message.version>1.0.1</gravitee-reactor-message.version>
+        <gravitee-apim.version>4.6.4</gravitee-apim.version>
+
+        <gravitee-sse.version>5.0.0</gravitee-sse.version>
+        <gravitee-http-post.version>2.1.0</gravitee-http-post.version>
+        <gravitee-reactor-message.version>5.0.0</gravitee-reactor-message.version>
 
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
@@ -53,23 +51,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Gravitee dependencies -->
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.policy</groupId>
-                <artifactId>gravitee-policy-api</artifactId>
-                <version>${gravitee-policy-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.gateway</groupId>
-                <artifactId>gravitee-gateway-api</artifactId>
-                <version>${gravitee-gateway-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -79,14 +68,12 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
-            <version>${gravitee-gateway-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
-            <version>${gravitee-policy-api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,7 @@
     <properties>
         <gravitee-bom.version>6.0.3</gravitee-bom.version>
         <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
-        <gravitee-node.version>4.0.0</gravitee-node.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>2.1.1</gravitee-common.version>
         <gravitee-apim.version>4.0.0-SNAPSHOT</gravitee-apim.version>
         <gravitee-sse.version>4.0.0</gravitee-sse.version>
         <gravitee-http-post.version>1.0.0</gravitee-http-post.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.2</version>
+        <version>22.2.5</version>
     </parent>
 
     <properties>
@@ -47,7 +47,6 @@
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
 
-        <maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.2.1</maven-plugin-properties.version>
 
         <!-- Property used by the publication job in CI-->
@@ -255,7 +254,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-plugin-assembly.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/src/test/java/io/gravitee/policy/latency/LatencyPolicyIntegrationV4Test.java
+++ b/src/test/java/io/gravitee/policy/latency/LatencyPolicyIntegrationV4Test.java
@@ -131,7 +131,7 @@ class LatencyPolicyIntegrationV4Test extends AbstractPolicyTest<LatencyPolicy, L
     @Test
     @DeployApi("/apis/latency-v4-message-publish.json")
     void should_apply_latency_on_request_message(HttpClient httpClient, VertxTestContext vertxTestContext) throws InterruptedException {
-        prepareReporter(vertxTestContext, 3);
+        prepareReporter(vertxTestContext, 4);
         Checkpoint responseCheckpoint = vertxTestContext.checkpoint();
         httpClient
             .rxRequest(POST, "/test")
@@ -157,7 +157,7 @@ class LatencyPolicyIntegrationV4Test extends AbstractPolicyTest<LatencyPolicy, L
     @Test
     @DeployApi("/apis/latency-v4-message-subscribe.json")
     void should_apply_latency_on_response_message(HttpClient httpClient, VertxTestContext vertxTestContext) throws InterruptedException {
-        prepareReporter(vertxTestContext, 3);
+        prepareReporter(vertxTestContext, 4);
         Checkpoint responseCheckpoint = vertxTestContext.checkpoint();
         httpClient
             .rxRequest(HttpMethod.GET, "/test")


### PR DESCRIPTION
**Description**

Bump dependencies and update Renovate config to use preset.

Tests have been updated because APIM reports metrics twice for message
APIs (at the beginning of the request and when it is done)

We keep using deprecated classes (Policy, HttpExecutionContext...) to
be backward compatible with APIM < 4.6

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-latency/2.0.1/gravitee-policy-latency-2.0.1.zip)
  <!-- Version placeholder end -->
